### PR TITLE
[DO NOT MERGE] Tracks Operator Fee Fixes backported onto v55 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4473,9 +4473,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4484,9 +4484,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4495,9 +4495,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]

--- a/crates/revm/src/optimism/handler_register.rs
+++ b/crates/revm/src/optimism/handler_register.rs
@@ -68,11 +68,6 @@ pub fn validate_env<SPEC: Spec, DB: Database>(env: &Env) -> Result<(), EVMError<
 pub fn validate_tx_against_state<SPEC: Spec, EXT, DB: Database>(
     context: &mut Context<EXT, DB>,
 ) -> Result<(), EVMError<DB::Error>> {
-    // No validation is needed for deposit transactions, as they are pre-verified on L1.
-    if context.evm.inner.env.tx.optimism.source_hash.is_some() {
-        return Ok(());
-    }
-
     // storage l1 block info for later use. l1_block_info is cleared after execution.
     if context.evm.inner.l1_block_info.is_none() {
         // the L1-cost fee is only computed for Optimism non-deposit transactions.
@@ -80,6 +75,11 @@ pub fn validate_tx_against_state<SPEC: Spec, EXT, DB: Database>(
             crate::optimism::L1BlockInfo::try_fetch(&mut context.evm.inner.db, SPEC::SPEC_ID)
                 .map_err(EVMError::Database)?;
         context.evm.inner.l1_block_info = Some(l1_block_info);
+    }
+
+    // No validation is needed for deposit transactions, as they are pre-verified on L1.
+    if context.evm.inner.env.tx.optimism.source_hash.is_some() {
+        return Ok(());
     }
 
     let env @ Env { cfg, tx, .. } = context.evm.inner.env.as_ref();
@@ -279,14 +279,13 @@ pub fn reimburse_caller<SPEC: Spec, EXT, DB: Database>(
     context: &mut Context<EXT, DB>,
     gas: &Gas,
 ) -> Result<(), EVMError<DB::Error>> {
-    mainnet::reimburse_caller::<SPEC, EXT, DB>(context, gas)?;
+    let is_deposit = context.evm.inner.env.tx.optimism.source_hash.is_some();
 
-    if context.evm.inner.env.tx.optimism.source_hash.is_none() {
-        let caller_account = context
-            .evm
-            .inner
-            .journaled_state
-            .load_account(context.evm.inner.env.tx.caller, &mut context.evm.inner.db)?;
+    if !is_deposit {
+        mainnet::reimburse_caller::<SPEC, EXT, DB>(context, gas)?;
+    }
+
+    if SPEC::SPEC_ID.is_enabled_in(SpecId::ISTHMUS) {
         let operator_fee_refund = context
             .evm
             .inner
@@ -294,6 +293,12 @@ pub fn reimburse_caller<SPEC: Spec, EXT, DB: Database>(
             .as_ref()
             .expect("L1BlockInfo should be loaded")
             .operator_fee_refund(gas, SPEC::SPEC_ID);
+
+        let caller_account = context
+            .evm
+            .inner
+            .journaled_state
+            .load_account(context.evm.inner.env.tx.caller, &mut context.evm.inner.db)?;
 
         // In additional to the normal transaction fee, additionally refund the caller
         // for the operator fee.
@@ -367,10 +372,8 @@ pub fn deduct_caller<SPEC: Spec, EXT, DB: Database>(
 
         // Deduct the operator fee from the caller's account.
         let gas_limit = U256::from(context.evm.inner.env.tx.gas_limit);
-
         let operator_fee_charge =
             l1_block.operator_fee_charge(enveloped_tx, gas_limit, SPEC::SPEC_ID);
-
         caller_account.info.balance = caller_account
             .info
             .balance
@@ -438,15 +441,18 @@ pub fn reward_beneficiary<SPEC: Spec, EXT, DB: Database>(
             .basefee
             .mul(U256::from(gas.spent() - gas.refunded() as u64));
 
-        // Send the operator fee of the transaction to the coinbase.
-        let mut operator_fee_vault_account = context
-            .evm
-            .inner
-            .journaled_state
-            .load_account(OPERATOR_FEE_RECIPIENT, &mut context.evm.inner.db)?;
+        // We can only touch the operator fee vault if the Isthmus spec is enabled.
+        if SPEC::SPEC_ID.is_enabled_in(SpecId::ISTHMUS) {
+            // Send the operator fee of the transaction to the coinbase.
+            let mut operator_fee_vault_account = context
+                .evm
+                .inner
+                .journaled_state
+                .load_account(OPERATOR_FEE_RECIPIENT, &mut context.evm.inner.db)?;
 
-        operator_fee_vault_account.mark_touch();
-        operator_fee_vault_account.data.info.balance += operator_fee_cost;
+            operator_fee_vault_account.mark_touch();
+            operator_fee_vault_account.data.info.balance += operator_fee_cost;
+        }
     }
     Ok(())
 }

--- a/crates/revm/src/optimism/l1block.rs
+++ b/crates/revm/src/optimism/l1block.rs
@@ -192,12 +192,18 @@ impl L1BlockInfo {
     /// Introduced in isthmus. Prior to isthmus, the operator fee is always zero.
     pub fn operator_fee_charge(&self, input: &[u8], gas_limit: U256, spec_id: SpecId) -> U256 {
         // If the input is a deposit transaction or empty, the default value is zero.
-        if input.is_empty() || input.first() == Some(&0x7F) {
+        if input.is_empty() || input.first() == Some(&0x7E) {
             return U256::ZERO;
         }
         if !spec_id.is_enabled_in(SpecId::ISTHMUS) {
             return U256::ZERO;
         }
+
+        self.operator_fee_charge_inner(gas_limit)
+    }
+
+    /// Calculate the operator fee for the given `gas`.
+    fn operator_fee_charge_inner(&self, gas: U256) -> U256 {
         let operator_fee_scalar = self
             .operator_fee_scalar
             .expect("Missing operator fee scalar for isthmus L1 Block");
@@ -205,8 +211,8 @@ impl L1BlockInfo {
             .operator_fee_constant
             .expect("Missing operator fee constant for isthmus L1 Block");
 
-        let product = gas_limit.saturating_mul(operator_fee_scalar)
-            / (U256::from(OPERATOR_FEE_SCALAR_DECIMAL));
+        let product =
+            gas.saturating_mul(operator_fee_scalar) / (U256::from(OPERATOR_FEE_SCALAR_DECIMAL));
 
         product.saturating_add(operator_fee_constant)
     }
@@ -219,15 +225,12 @@ impl L1BlockInfo {
             return U256::ZERO;
         }
 
-        let operator_fee_scalar = self
-            .operator_fee_scalar
-            .expect("Missing operator fee scalar for isthmus L1 Block");
+        let operator_cost_gas_limit = self.operator_fee_charge_inner(U256::from(gas.limit()));
+        let operator_cost_gas_used = self.operator_fee_charge_inner(U256::from(
+            gas.limit() - (gas.remaining() + gas.refunded() as u64),
+        ));
 
-        // We're computing the difference between two operator fees, so no need to include the
-        // constant.
-
-        operator_fee_scalar.saturating_mul(U256::from(gas.remaining() + gas.refunded() as u64))
-            / (U256::from(OPERATOR_FEE_SCALAR_DECIMAL))
+        operator_cost_gas_limit.saturating_sub(operator_cost_gas_used)
     }
 
     /// Calculate the data gas for posting the transaction on L1. Calldata costs 16 gas per byte
@@ -288,7 +291,7 @@ impl L1BlockInfo {
             return tx_l1_cost;
         }
         // If the input is a deposit transaction or empty, the default value is zero.
-        let tx_l1_cost = if input.is_empty() || input.first() == Some(&0x7F) {
+        let tx_l1_cost = if input.is_empty() || input.first() == Some(&0x7E) {
             return U256::ZERO;
         } else if spec_id.is_enabled_in(SpecId::FJORD) {
             self.calculate_tx_l1_cost_fjord(input)
@@ -451,8 +454,8 @@ mod tests {
         assert_eq!(gas_cost, U256::ZERO);
         l1_block_info.clear_tx_l1_cost();
 
-        // Deposit transactions with the EIP-2718 type of 0x7F should result in zero
-        let input = bytes!("7FFACADE");
+        // Deposit transactions with the EIP-2718 type of 0x7E should result in zero
+        let input = bytes!("7EFACADE");
         let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, SpecId::REGOLITH);
         assert_eq!(gas_cost, U256::ZERO);
         l1_block_info.clear_tx_l1_cost();
@@ -483,8 +486,8 @@ mod tests {
         assert_eq!(gas_cost, U256::ZERO);
         l1_block_info.clear_tx_l1_cost();
 
-        // Deposit transactions with the EIP-2718 type of 0x7F should result in zero
-        let input = bytes!("7FFACADE");
+        // Deposit transactions with the EIP-2718 type of 0x7E should result in zero
+        let input = bytes!("7EFACADE");
         let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, SpecId::ECOTONE);
         assert_eq!(gas_cost, U256::ZERO);
         l1_block_info.clear_tx_l1_cost();
@@ -539,8 +542,8 @@ mod tests {
         assert_eq!(gas_cost, U256::ZERO);
         l1_block_info.clear_tx_l1_cost();
 
-        // Deposit transactions with the EIP-2718 type of 0x7F should result in zero
-        let input = bytes!("7FFACADE");
+        // Deposit transactions with the EIP-2718 type of 0x7E should result in zero
+        let input = bytes!("7EFACADE");
         let gas_cost = l1_block_info.calculate_tx_l1_cost(&input, SpecId::FJORD);
         assert_eq!(gas_cost, U256::ZERO);
     }


### PR DESCRIPTION
### Description

- Fixes deposit tx identifier to be `126` (or `0x7E`) instead of the incorrect `0x7F`