### PR TITLE
fix: operator fee state missmatch

### DIFF
--- a/crates/revm/src/optimism/handler_register.rs
+++ b/crates/revm/src/optimism/handler_register.rs
@@ -68,11 +68,6 @@ pub fn validate_env<SPEC: Spec, DB: Database>(env: &Env) -> Result<(), EVMError<
 pub fn validate_tx_against_state<SPEC: Spec, EXT, DB: Database>(
     context: &mut Context<EXT, DB>,
 ) -> Result<(), EVMError<DB::Error>> {
-    // No validation is needed for deposit transactions, as they are pre-verified on L1.
-    if context.evm.inner.env.tx.optimism.source_hash.is_some() {
-        return Ok(());
-    }
-
     // storage l1 block info for later use. l1_block_info is cleared after execution.
     if context.evm.inner.l1_block_info.is_none() {
         // the L1-cost fee is only computed for Optimism non-deposit transactions.
@@ -80,6 +75,11 @@ pub fn validate_tx_against_state<SPEC: Spec, EXT, DB: Database>(
             crate::optimism::L1BlockInfo::try_fetch(&mut context.evm.inner.db, SPEC::SPEC_ID)
                 .map_err(EVMError::Database)?;
         context.evm.inner.l1_block_info = Some(l1_block_info);
+    }
+
+    // No validation is needed for deposit transactions, as they are pre-verified on L1.
+    if context.evm.inner.env.tx.optimism.source_hash.is_some() {
+        return Ok(());
     }
 
     let env @ Env { cfg, tx, .. } = context.evm.inner.env.as_ref();
@@ -285,7 +285,7 @@ pub fn reimburse_caller<SPEC: Spec, EXT, DB: Database>(
         mainnet::reimburse_caller::<SPEC, EXT, DB>(context, gas)?;
     }
 
-    if !is_deposit && SPEC::SPEC_ID.is_enabled_in(SpecId::ISTHMUS) {
+    if SPEC::SPEC_ID.is_enabled_in(SpecId::ISTHMUS) {
         let operator_fee_refund = context
             .evm
             .inner

--- a/crates/revm/src/optimism/l1block.rs
+++ b/crates/revm/src/optimism/l1block.rs
@@ -229,8 +229,9 @@ impl L1BlockInfo {
         }
 
         let operator_cost_gas_limit = self.operator_fee_charge_inner(U256::from(gas.limit()));
-        let operator_cost_gas_used =
-            self.operator_fee_charge_inner(U256::from(gas.limit() - gas.remaining()));
+        let operator_cost_gas_used = self.operator_fee_charge_inner(U256::from(
+            gas.limit() - (gas.remaining() + gas.refunded() as u64),
+        ));
 
         operator_cost_gas_limit.saturating_sub(operator_cost_gas_used)
     }


### PR DESCRIPTION
This PR contains 2 fixes:

* Remove a if to reimburse caller for deposits
* Use the same formula as op-geth to compute operator fee refund and avoid a 1 wei diff