### PR TITLE
fix: empty input and deposits refunds

### DIFF
--- a/crates/revm/src/optimism/l1block.rs
+++ b/crates/revm/src/optimism/l1block.rs
@@ -191,8 +191,8 @@ impl L1BlockInfo {
     ///
     /// Introduced in isthmus. Prior to isthmus, the operator fee is always zero.
     pub fn operator_fee_charge(&self, input: &[u8], gas_limit: U256, spec_id: SpecId) -> U256 {
-        // If the input is a deposit transaction or empty, the default value is zero.
-        if input.is_empty() || input.first() == Some(&0x7E) {
+        // If the input is a deposit transaction, the default value is zero.
+        if input.first() == Some(&0x7E) {
             return U256::ZERO;
         }
         if !spec_id.is_enabled_in(SpecId::ISTHMUS) {


### PR DESCRIPTION
In this PR:

- Don't charge 0 operator fee if the tx input is empty
- Don't reimburse caller for deposits (this revert a previous commit)